### PR TITLE
Fix the parameters of main() in common_catch_main.c

### DIFF
--- a/cpp/tests/common_catch_main.cc
+++ b/cpp/tests/common_catch_main.cc
@@ -8,7 +8,7 @@
 
 std::unique_ptr<std::mt19937_64> mersenne(new std::mt19937_64(0));
 
-int main(int argc, char const *argv[]) {
+int main(int argc, char *const *argv) {
   Catch::Session session; // There must be exactly once instance
 
   int returnCode = session.applyCommandLine(argc, argv);


### PR DESCRIPTION
This solves the following compiler error seen on Debian Stretch:

```
/build/sopt-2.0.0/cpp/tests/common_catch_main.cc: In function 'int main(int, const char**)':
/build/sopt-2.0.0/cpp/tests/common_catch_main.cc:14:55: error: invalid conversion from 'const char**' to 'char* const*' [-fpermissive]
   int returnCode = session.applyCommandLine(argc, argv);
                                                       ^
In file included from /build/sopt-2.0.0/cpp/tests/common_catch_main.cc:4:0:
/usr/include/catch.hpp:5680:13: note:   initializing argument 2 of 'int Catch::Session::applyCommandLine(int, char* const*, Catch::Session::OnUnusedOptions::DoWhat)'
         int applyCommandLine( int argc, char* const argv[], OnUnusedOptions::DoWhat unusedOptionBehaviour = OnUnusedOptions::Fail ) {
             ^~~~~~~~~~~~~~~~
```